### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/890/442/521/890442521.geojson
+++ b/data/890/442/521/890442521.geojson
@@ -401,6 +401,9 @@
     },
     "wof:country":"SJ",
     "wof:created":1469052365,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"967fdcfff048f2c3341390323676e7c4",
     "wof:hierarchy":[
         {
@@ -411,7 +414,7 @@
         }
     ],
     "wof:id":890442521,
-    "wof:lastmodified":1566645313,
+    "wof:lastmodified":1582358652,
     "wof:name":"Longyearbyen",
     "wof:parent_id":85675539,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.