### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/601/231/9/1126012319.geojson
+++ b/data/112/601/231/9/1126012319.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0646\u064a \u0623\u0648\u0644\u064a\u0633\u0648\u0646\u062f"
+    ],
+    "name:arz_x_preferred":[
+        "\u0646\u0649 \u0627\u0648\u0644\u064a\u0633\u0648\u0646\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Ny-\u00c5lesund"
+    ],
     "name:bre_x_preferred":[
         "Ny-\u00c5lesund"
     ],
@@ -29,6 +38,9 @@
         "\u041d\u044e \u041e\u043b\u0435\u0441\u0443\u043d"
     ],
     "name:cat_x_preferred":[
+        "Ny-\u00c5lesund"
+    ],
+    "name:ces_x_preferred":[
         "Ny-\u00c5lesund"
     ],
     "name:dan_x_preferred":[
@@ -48,6 +60,9 @@
     ],
     "name:ext_x_preferred":[
         "Ny-\u00c5lesund"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06cc\u0648\u0627\u0648\u0644\u0633\u0646"
     ],
     "name:fin_x_preferred":[
         "Ny-\u00c5lesund"
@@ -105,6 +120,9 @@
     ],
     "name:por_x_variant":[
         "Ny-\u00c5lesund"
+    ],
+    "name:pus_x_preferred":[
+        "\u0646\u064a-\u0627\u0648\u0644\u0633\u0648\u0646\u062f"
     ],
     "name:ron_x_preferred":[
         "Ny-Aalesund"
@@ -167,7 +185,7 @@
         }
     ],
     "wof:id":1126012319,
-    "wof:lastmodified":1566645313,
+    "wof:lastmodified":1690863846,
     "wof:name":"Ny-\u00c5lesund",
     "wof:parent_id":85675539,
     "wof:placetype":"locality",

--- a/data/890/412/901/890412901.geojson
+++ b/data/890/412/901/890412901.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u0631\u0627\u0645\u064a\u062f\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Pyramiden"
+    ],
     "name:bos_x_preferred":[
         "Pyramiden"
     ],
@@ -136,7 +142,7 @@
         }
     ],
     "wof:id":890412901,
-    "wof:lastmodified":1566645312,
+    "wof:lastmodified":1690863845,
     "wof:name":"Pyramiden",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/265/890424265.geojson
+++ b/data/890/424/265/890424265.geojson
@@ -22,6 +22,12 @@
     "name:afr_x_preferred":[
         "Olonkinbyen"
     ],
+    "name:ara_x_preferred":[
+        "\u0623\u0648\u0644\u0648\u0646\u0643\u064a\u0646\u0628\u064a\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Olonkinbyen"
+    ],
     "name:aze_x_preferred":[
         "Olonkinbyuen"
     ],
@@ -34,10 +40,16 @@
     "name:ces_x_preferred":[
         "Olonkinbyen"
     ],
+    "name:cym_x_preferred":[
+        "Olonkinbyen"
+    ],
     "name:dan_x_preferred":[
         "Olonkinbyen"
     ],
     "name:deu_x_preferred":[
+        "Olonkinbyen"
+    ],
+    "name:diq_x_preferred":[
         "Olonkinbyen"
     ],
     "name:eng_x_preferred":[
@@ -82,6 +94,9 @@
     "name:mkd_x_preferred":[
         "\u041e\u043b\u043e\u043d\u043a\u0438\u043d\u0431\u0438\u0435\u043d"
     ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0644\u0648\u0646\u06a9\u06cc\u0646\u200c\u0628\u06cc\u0646"
+    ],
     "name:nld_x_preferred":[
         "Olonkinstad"
     ],
@@ -114,6 +129,9 @@
     ],
     "name:tur_x_preferred":[
         "Olonkinbyen"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041e\u043b\u043e\u043d\u043a\u0456\u043d\u0431\u0443\u0435\u043d"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0648\u0644\u0648\u0646\u06a9\u0646\u0628\u06cc\u0646"
@@ -148,7 +166,7 @@
         }
     ],
     "wof:id":890424265,
-    "wof:lastmodified":1566645313,
+    "wof:lastmodified":1690863845,
     "wof:name":"Olonkinbyen",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/521/890442521.geojson
+++ b/data/890/442/521/890442521.geojson
@@ -28,17 +28,32 @@
     "name:ara_x_variant":[
         "\u0644\u0648\u0646\u063a\u064a\u064a\u0631\u0628\u064a\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0646\u062c\u064a\u064a\u0631\u0628\u064a\u0646"
+    ],
     "name:ast_x_preferred":[
         "Longyearbyen"
     ],
     "name:aze_x_preferred":[
         "Lonqyirbyuen"
     ],
+    "name:bar_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041b\u043e\u043d\u0433\u0439\u0456\u0440"
     ],
+    "name:bel_x_variant":[
+        "\u041b\u043e\u043d\u0433\u0439\u0456\u0440"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u0999\u09cd\u0997\u09af\u09bc\u09c7\u09ac\u09be\u09af\u09bc\u09c7\u09a8"
+    ],
+    "name:bos_x_preferred":[
+        "Longyearbyen"
     ],
     "name:bre_x_preferred":[
         "Longyearbyen"
@@ -58,6 +73,9 @@
     "name:chv_x_preferred":[
         "\u041b\u043e\u043d\u0433\u044c\u0438\u0440"
     ],
+    "name:csb_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:cym_x_preferred":[
         "Longyearbyen"
     ],
@@ -65,6 +83,12 @@
         "Longyearbyen"
     ],
     "name:deu_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:diq_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:dsb_x_preferred":[
         "Longyearbyen"
     ],
     "name:ell_x_preferred":[
@@ -106,10 +130,22 @@
     "name:fry_x_preferred":[
         "Longyearbyen"
     ],
+    "name:fur_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:gla_x_preferred":[
         "Longyearbyen"
     ],
+    "name:gle_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:glg_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:glv_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:gsw_x_preferred":[
         "Longyearbyen"
     ],
     "name:guj_x_preferred":[
@@ -122,6 +158,9 @@
         "\u0932\u0949\u0902\u0917\u0907\u092f\u0930\u092c\u094d\u092f\u0947\u0928"
     ],
     "name:hrv_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:hsb_x_preferred":[
         "Longyearbyen"
     ],
     "name:hun_x_preferred":[
@@ -148,6 +187,9 @@
     "name:jpn_x_preferred":[
         "\u30ed\u30f3\u30b0\u30a4\u30a7\u30fc\u30eb\u30d3\u30fc\u30f3"
     ],
+    "name:kal_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:kan_x_preferred":[
         "\u0cb2\u0cbe\u0c82\u0c97\u0ccd\u0c87\u0caf\u0cb0\u0ccd\u0cac\u0cc8\u0ca8\u0ccd"
     ],
@@ -157,14 +199,41 @@
     "name:kor_x_preferred":[
         "\ub871\uc704\uc5d0\uc544\ub974\ubdd4\uc5d4"
     ],
+    "name:kor_x_variant":[
+        "\ub871\uc774\uc5b4\ube44\uc5d4"
+    ],
+    "name:ksh_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:lad_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:lat_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:lav_x_preferred":[
         "Longj\u0113rb\u012bene"
     ],
     "name:lav_x_variant":[
         "Longjerb\u012bene"
     ],
+    "name:lfn_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:lim_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:lit_x_preferred":[
         "Longjyrbienas"
+    ],
+    "name:liv_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:ltg_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:ltz_x_preferred":[
+        "Longyearbyen"
     ],
     "name:mar_x_preferred":[
         "\u0932\u0949\u0928\u094d\u0917\u092f\u0947\u0930\u094d\u092c\u093e\u0907\u0928"
@@ -181,7 +250,13 @@
     "name:myv_x_preferred":[
         "\u041b\u043e\u043d\u0433\u0439\u0438\u0440\u0431\u044e\u0435\u043d \u043e\u0448"
     ],
+    "name:mzn_x_preferred":[
+        "\u0644\u0627\u0646\u06af\u06cc\u0631\u0628\u06cc\u0646"
+    ],
     "name:nan_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:nds_x_preferred":[
         "Longyearbyen"
     ],
     "name:nld_x_preferred":[
@@ -205,10 +280,34 @@
     "name:oss_x_preferred":[
         "\u041b\u043e\u043d\u0433\u0439\u0438\u0440"
     ],
+    "name:pcd_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:pdc_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:pfl_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:pih_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:pms_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:pol_x_preferred":[
         "Longyearbyen"
     ],
     "name:por_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:prg_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:pus_x_preferred":[
+        "\u0644\u0627\u0646\u06ab\u06cc\u0631\u0628\u06cc\u0646"
+    ],
+    "name:roh_x_preferred":[
         "Longyearbyen"
     ],
     "name:ron_x_preferred":[
@@ -223,6 +322,9 @@
     "name:sin_x_preferred":[
         "\u0dbd\u0ddd\u0db1\u0dca\u0d9c\u0dca\u0d89\u0dba\u0dbb\u0dca\u0db6\u0dba\u0dd2\u0db1\u0dca"
     ],
+    "name:sli_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:slk_x_preferred":[
         "Longyearbyen"
     ],
@@ -235,8 +337,14 @@
     "name:spa_x_preferred":[
         "Longyearbyen"
     ],
+    "name:sqi_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:srp_x_preferred":[
         "\u041b\u043e\u043d\u0433\u0458\u0438\u0440"
+    ],
+    "name:stq_x_preferred":[
+        "Longyearbyen"
     ],
     "name:swa_x_preferred":[
         "Longyearbyen"
@@ -268,7 +376,37 @@
     "name:urd_x_preferred":[
         "\u0644\u0627\u0646\u06af\u0627\u06cc\u0631\u0628\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vep_x_preferred":[
+        "Longyearbyen"
+    ],
     "name:vie_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vls_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vmf_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vol_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vot_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:vro_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:war_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:wln_x_preferred":[
+        "Longyearbyen"
+    ],
+    "name:wol_x_preferred":[
         "Longyearbyen"
     ],
     "name:wuu_x_preferred":[
@@ -417,7 +555,7 @@
         }
     ],
     "wof:id":890442521,
-    "wof:lastmodified":1636502855,
+    "wof:lastmodified":1690863845,
     "wof:name":"Longyearbyen",
     "wof:parent_id":85675539,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.